### PR TITLE
fix: plugin config + user-reported bugs + design quality + sanity fixes (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "magician",
       "description": "Full-stack SDLC plugin with dynamic project inspection, team memory, self-learning, and parallel agent orchestration",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "source": "./",
       "author": {
         "name": "Alexander Tyagunov",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magician",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Full-stack SDLC plugin with dynamic project inspection, team memory, self-learning, and parallel agent orchestration",
   "author": {
     "name": "Alexander Tyagunov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] — 2026-04-29
+## [1.3.0] — 2026-05-03
+
+### Fixed
+- `scripts/pattern-detect.sh`: replaced invalid `{"decision":"suggest"}` and `{"decision":"ask"}` hook JSON with correct `{"additionalContext":"..."}` format — fixes /magic auto-invoke and pattern suggestion delivery
+- `scripts/format.sh`: fixed hook input extraction to use `tool_input` key (consistent with other scripts)
+- `skills/seal/SKILL.md`: fixed step numbering after docs update insertion (was duplicate step 5)
+- `skills/summon/SKILL.md`: added missing `/magic` to the skill registry injected into every subagent
+
+### Added
+- `skills/conjure/SKILL.md`: design personality commitment gate before any CSS — forces a named aesthetic direction (editorial, brutalist, luxury, retro-futuristic, etc.); explicitly bans default AI aesthetics (Inter, purple gradients, generic card layouts); alternates light/dark base; brand book now captures personality + motion + spatial character, not just hex values
+
+## [1.2.0] — 2026-05-03
 
 ### Fixed
 - `marketplace.json`: renamed top-level `name` from `"magician-marketplace"` to `"magician"` to match the expected URL slug at `claude.com/plugins/magician`
 - `marketplace.json`: moved `description` out of non-standard `metadata` wrapper to root level per official schema
 - `marketplace.json`: replaced github-ref source with `"./"` self-reference (matches the pattern used by officially published plugins)
 - `marketplace.json`: removed redundant `homepage`, `repository`, `license`, `keywords`, and `category` from plugin entry — not present in reference implementations
+- `scripts/access-tracker.sh`: removed invalid `{"decision":"ask"}` JSON hook output that caused `Hook JSON output validation failed`; now emits plain text which the harness injects as context
+- `/portal`: accepts feature name via `$ARGUMENTS` so `/manifest` can pass it directly without re-prompting the user
+- `/manifest`: worktree creation is now a user gate (GATE 3.5) with an explicit branch name proposal; added `Autonomous Continuation` rule so manifest drives through blueprint → orchestrate without stopping
+- `/certify`: UI projects now auto-open the browser after starting the dev server
+- `/seal`: added docs update step (CLAUDE.md + README) before commit
+- `/conjure`: creates `.workspace/shared/brand.md` before the first UI mockup if absent; all subsequent mockups reference it for visual consistency
+
+### Added
+- Agent color identifiers: reviewer (orange), sentinel (red), simplifier (cyan), verifier (green) — visible in the Claude Code UI when agents are working
+
+### Changed
+- README installation simplified to single command: `/plugin install github:Alexander-Tyagunov/magician`
 
 ## [1.1.1] — 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Inspects your project, assembles the right knowledge automatically, orchestrates parallel agents, learns from every session, and ships clean code — from idea to merged PR, autonomously.
 
-[![Version](https://img.shields.io/badge/version-1.2.0-6c63ff)](https://github.com/Alexander-Tyagunov/magician/releases)
+[![Version](https://img.shields.io/badge/version-1.3.0-6c63ff)](https://github.com/Alexander-Tyagunov/magician/releases)
 [![License](https://img.shields.io/badge/license-MIT-43e97b)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-%E2%9D%A4-ff6584)](https://github.com/sponsors/Alexander-Tyagunov)
 
@@ -163,16 +163,7 @@ flowchart TD
 
 ## Installation
 
-### Add the marketplace and install
-
-```bash
-/plugin marketplace add https://github.com/Alexander-Tyagunov/magician
-/plugin install magician@magician-marketplace
 ```
-
-### Or install directly
-
-```bash
 /plugin install github:Alexander-Tyagunov/magician
 ```
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,3 +1,8 @@
+---
+name: reviewer
+color: orange
+---
+
 # Code Reviewer Agent
 
 You are a code correctness reviewer. Your job is to find bugs, logic errors, and edge cases.

--- a/agents/sentinel.md
+++ b/agents/sentinel.md
@@ -1,3 +1,8 @@
+---
+name: sentinel
+color: red
+---
+
 # Sentinel Security Agent
 
 You are a security reviewer. Your job is to find vulnerabilities and attack surfaces.

--- a/agents/simplifier.md
+++ b/agents/simplifier.md
@@ -1,3 +1,8 @@
+---
+name: simplifier
+color: cyan
+---
+
 # Simplifier Agent
 
 You are a code simplification reviewer. Your job is to find over-engineering and unnecessary complexity.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,3 +1,8 @@
+---
+name: verifier
+color: green
+---
+
 # Verifier Agent
 
 You are a test and verification reviewer. Your job is to ensure correctness is proven, not assumed.

--- a/scripts/access-tracker.sh
+++ b/scripts/access-tracker.sh
@@ -68,17 +68,14 @@ for ancestor in [str(p.parent), str(p.parent.parent)]:
     if by_parent[ancestor] == 3 and ancestor not in suggested:
         suggested.append(ancestor)
         rel = os.path.relpath(ancestor)
-        print(json.dumps({
-            "decision": "ask",
-            "message": (
-                f"I've now read 3 or more files from `{rel}/`. "
-                f"Two options worth considering:\n"
-                f"• If this directory contains proprietary or sensitive code, add "
-                f"`\"Read(**/{rel}/**)\"` to the deny list in settings.json.\n"
-                f"• If broad access here is intentional and you want to suppress "
-                f"future prompts, that's fine too — just let me know."
-            )
-        }))
+        print(
+            f"I've now read 3 or more files from `{rel}/`. "
+            f"Two options worth considering:\n"
+            f"• If this directory contains proprietary or sensitive code, add "
+            f"`\"Read(**/{rel}/**)\"` to the deny list in settings.json.\n"
+            f"• If broad access here is intentional and you want to suppress "
+            f"future prompts, that's fine too — just let me know."
+        )
         break  # one suggestion per read event
 
 # Persist, cap at 1000 paths

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -9,7 +9,7 @@ FILE_PATH=$(python3 - "$INPUT" <<'PYEOF'
 import json, sys
 try:
     d = json.loads(sys.argv[1])
-    inp = d.get("input", d)
+    inp = d.get("tool_input", d.get("input", d))
     print(inp.get("file_path", inp.get("path", "")) if isinstance(inp, dict) else "")
 except:
     pass

--- a/scripts/pattern-detect.sh
+++ b/scripts/pattern-detect.sh
@@ -62,8 +62,7 @@ is_short = len(prompt.split()) < 4
 if (magic_hit or magic_phrase_hit) and not already_invoking and not is_short:
     matched = list(magic_hit)[:2] or magic_phrase_hit[:1]
     print(json.dumps({
-        "decision": "suggest",
-        "message": (
+        "additionalContext": (
             "[MAGICIAN] Research/analysis intent detected ({}). "
             "Auto-activating /magic skill. Invoke magician:magic before responding to this request."
         ).format(", ".join(str(m) for m in matched))
@@ -89,13 +88,11 @@ if best_match:
     count = best_match["count"]
     if count == 3:
         print(json.dumps({
-            "decision": "ask",
-            "message": "I've seen this type of request 3 times now. Would you like me to create a reusable skill for it using /inscribe?"
+            "additionalContext": "I've seen this type of request 3 times now. Would you like me to create a reusable skill for it using /inscribe?"
         }))
     elif count == 5:
         print(json.dumps({
-            "decision": "ask",
-            "message": "This pattern has come up 5 times. I'll draft a skill — invoke /inscribe to review and save it."
+            "additionalContext": "This pattern has come up 5 times. I'll draft a skill — invoke /inscribe to review and save it."
         }))
 else:
     patterns.append({

--- a/skills/certify/SKILL.md
+++ b/skills/certify/SKILL.md
@@ -51,10 +51,18 @@ After all checks pass, write a brief evidence summary:
 ```
 
 ## For UI Projects
-If the project has a UI, run the dev server and manually verify:
-- [ ] Golden path works end-to-end
-- [ ] Edge cases handled gracefully
-- [ ] No console errors
+If the project has a UI:
+1. Start the dev server (e.g. `npm run dev`, `yarn dev`) in the background
+2. Auto-open the browser to the local URL:
+   ```bash
+   # detect and open
+   URL=$(grep -E '"dev"' package.json | grep -oE 'localhost:[0-9]+' | head -1 || echo "localhost:3000")
+   open "http://$URL" 2>/dev/null || xdg-open "http://$URL" 2>/dev/null || true
+   ```
+3. Manually verify (or use Playwright if available):
+   - [ ] Golden path works end-to-end
+   - [ ] Edge cases handled gracefully
+   - [ ] No console errors
 
 ## Completion Signal
 

--- a/skills/conjure/SKILL.md
+++ b/skills/conjure/SKILL.md
@@ -55,7 +55,76 @@ Iterate on changes if requested. Only advance when user explicitly approves.
 ---
 ### GATE 3 — UI Design (skip if no UI involved)
 
-If the feature has a UI, present a mockup.
+If the feature has a UI:
+
+**Design personality gate — BEFORE any CSS or mockup:**
+
+This step prevents all mockups from looking the same. Do it every time, without exception.
+
+1. **Research context** — silently scan: existing CSS/Tailwind config, any brand assets, README, the product's name and purpose, target audience from spec. Note the tone: serious B2B tool? Playful consumer app? Developer utility? Financial product?
+
+2. **Commit to a bold aesthetic direction** — choose ONE from this list (or derive your own that fits the project):
+   - Brutally minimal — extreme whitespace, monochrome, single accent, nothing decorative
+   - Editorial / magazine — strong typographic hierarchy, oversized headlines, asymmetric layouts
+   - Luxury / refined — muted palette, serif headlines, subtle shadows, controlled density
+   - Retro-futuristic — geometric shapes, high contrast, bold angles, neon accent on dark
+   - Playful / toy-like — rounded everything, saturated pastels, bouncy micro-animations
+   - Industrial / utilitarian — dense layout, monospace type, low chrome, data-forward
+   - Organic / natural — earthy tones, fluid shapes, soft textures, warm neutrals
+   - Brutalist / raw — clashing fonts, visible structure, unexpected color collisions
+   - Art deco / geometric — symmetry, ornamental borders, gold/black, structured grids
+
+   **NEVER default to:** Inter/Roboto/system fonts, purple gradients on white, generic card layouts, Space Grotesk, "clean modern SaaS look." These produce identical output across every project.
+
+3. **Vary light/dark** — alternate between light and dark base themes across sessions. Do not always choose dark.
+
+4. **State your direction** — tell the user in one sentence: "I'm going with [direction] — [one-line rationale tied to the product]." Do not ask for approval; move forward. If they want something different they'll say so.
+
+**Brand book (first-time setup):** After committing to a direction, check whether `.workspace/shared/brand.md` exists. If not, create it now — the brand book must capture the *chosen aesthetic personality*, not just mechanical values:
+
+```markdown
+# Brand Book
+
+## Personality
+[One sentence: the aesthetic direction and why it fits this product]
+
+## Colors
+- Primary: #<hex>
+- Secondary: #<hex>
+- Background: #<hex>
+- Surface: #<hex>
+- Text: #<hex>
+- Accent: #<hex>
+- Error: #<hex>
+
+## Typography
+- Display font: <name + source — must be distinctive, not Inter/Roboto>
+- Body font: <name + source>
+- Heading scale: <sizes>
+- Body: <size/line-height>
+
+## Spatial style
+[Dense | Airy | Extreme whitespace | Controlled density]
+
+## Spacing scale
+Base: 4px — 4 / 8 / 16 / 24 / 32 / 48 / 64
+
+## Border radius: <value — 0px for sharp/brutalist, 4px for refined, 24px for playful>
+
+## Shadows: <none | subtle | dramatic>
+
+## Motion character
+[None | Subtle fades | Bouncy | Staggered reveals | Dramatic]
+
+## Component character
+- Button: <shape, weight, hover behavior>
+- Input: <border style, focus treatment>
+- Card: <elevation, border, background>
+```
+
+Derive from existing design tokens if present. Otherwise build from the chosen personality direction. Tell the user: "Brand book created at `.workspace/shared/brand.md` — all future mockups for this project reference it." All subsequent mockup CSS must stay consistent with this brand book.
+
+**Present a mockup.**
 
 **If visual mode:** write two files for every mockup — `$VC_SCREENS/v1/mockup.css` (all styles) first, then `$VC_SCREENS/v1/mockup.html` (HTML only, linking to it via `<link rel="stylesheet" href="mockup.css">`). No `<style>` blocks in the HTML. Apply frontend-design quality rules. Tell user the URL. End your turn. Iterate on versions if requested (keep paired naming: `mockup-v2.css` + `mockup-v2.html`). Capture a Playwright screenshot when approved.
 

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -33,13 +33,17 @@ GATE 4: PR title and final go-ahead (before /seal)
 ### Phase 2: Planning [GATE 3]
 8. Run /blueprint — create task plan with parallelism map
 9. Write plan to `.workspace/shared/plans/`
-10. **Wait for plan approval.**
+10. **Wait for plan approval. Do NOT proceed to Phase 3 until explicit approval arrives.**
 
-### Phase 3: Isolation
-11. Run /portal — create git worktree (or skip if disableGit)
+### Phase 3: Isolation [GATE 3.5]
+11. Propose a branch name derived from the feature (e.g. `feature/<kebab-case-name>`). Ask:
+    > "Ready to create a worktree for isolation. I'll use branch `feature/<name>`. Create it now, or work directly on the current branch?"
+    **End your turn. Wait for their reply.**
+    - If they confirm: run `/portal <name>` — passes the name directly, no re-prompting
+    - If they decline: note "working in current branch" and continue
 
 ### Phase 4: Implementation
-12. Run /orchestrate — execute all tasks using parallel agents where safe, sequential where required
+12. **Proceed immediately after Phase 3 without waiting.** Run /orchestrate — execute all tasks using parallel agents where safe, sequential where required
 13. /ward discipline enforced throughout (TDD)
 
 ### Phase 5: Verification
@@ -53,6 +57,10 @@ GATE 4: PR title and final go-ahead (before /seal)
 17. Run /certify again — clean state after review fixes
 18. Ask user for PR title. **Wait for approval.**
 19. Run /seal — simplify, commit, PR, monitor CI, merge
+
+## Autonomous Continuation
+
+After each sub-skill completes and prints its completion signal, **immediately proceed to the next phase**. Do not stop and ask "should I continue?" unless the phase is a defined GATE. Blueprint ending with "Run /orchestrate…" is a signal it is done — manifest continues autonomously from there.
 
 ## Reporting
 

--- a/skills/portal/SKILL.md
+++ b/skills/portal/SKILL.md
@@ -14,7 +14,7 @@ Read `.workspace/local/prefs.md` for `disableGit: true`. If set, skip all git op
 
 ## Process (git mode)
 
-1. **Get branch name** — ask: "What's this feature called? (I'll use it as the branch/worktree name.)" **End your turn. Wait for their answer before creating anything.**
+1. **Get branch name** — if `$ARGUMENTS` is non-empty, use it as the feature name directly. Otherwise ask: "What's this feature called? (I'll use it as the branch/worktree name.)" **End your turn. Wait for their answer before creating anything.**
 2. **Create worktree**:
    ```bash
    BRANCH="feature/<name>"

--- a/skills/seal/SKILL.md
+++ b/skills/seal/SKILL.md
@@ -21,7 +21,15 @@ Dispatch simplifier agent (`agents/simplifier.md`) for a final simplification sw
 ### 2. Final Certify
 Run /certify. All checks must pass before continuing.
 
-### 3. Commit
+### 3. Update Documentation
+Before committing, update docs to reflect the shipped feature:
+- **CLAUDE.md** — add or update any changed commands, env vars, architecture notes, or setup steps
+- **README.md** — update feature list, screenshots, or usage examples if the change is user-visible
+- Any other docs that reference the changed code (API docs, architecture diagrams, etc.)
+
+Keep updates minimal and accurate — document what changed, not the implementation details.
+
+### 4. Commit
 ```bash
 git add -A
 git commit -m "feat: <feature description>
@@ -31,12 +39,12 @@ git commit -m "feat: <feature description>
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ```
 
-### 4. Push
+### 5. Push
 ```bash
 git push -u origin <branch>
 ```
 
-### 5. Create PR
+### 6. Create PR
 Ask: "What should the PR title be?" **End your turn. Wait for their answer before running any `gh` command.**
 
 Once you have the title:
@@ -57,16 +65,16 @@ EOF
 )"
 ```
 
-### 6. Monitor CI
+### 7. Monitor CI
 ```bash
 gh pr checks --watch
 ```
 Wait for all checks to pass. If any fail: read the failure, fix, push, wait again.
 
-### 7. Review Comments
+### 8. Review Comments
 If reviewers add comments: use /absorb to process them, then /certify, then push.
 
-### 8. Merge (if auto-merge not enabled)
+### 9. Merge (if auto-merge not enabled)
 ```bash
 gh pr merge --squash --delete-branch
 ```

--- a/skills/summon/SKILL.md
+++ b/skills/summon/SKILL.md
@@ -20,8 +20,8 @@ Available skills: /conjure (design), /blueprint (planning), /forge (task executi
 /ward (TDD), /unravel (debugging), /certify (verification), /summon (spawn agents),
 /orchestrate (multi-agent run), /scrutinize (code review), /absorb (integrate review),
 /portal (git worktree), /seal (ship PR), /manifest (full SDLC), /almanac (workspace init),
-/chronicle (session history), /sentinel (security scan), /accelerate (performance),
-/deploy (CI/CD), /inscribe (write skills), /autopsy (post-mortem)
+/chronicle (session history), /magic (research & consulting), /sentinel (security scan),
+/accelerate (performance), /deploy (CI/CD), /inscribe (write skills), /autopsy (post-mortem)
 
 ## Process
 


### PR DESCRIPTION
Plugin config:
- Rename marketplace name to "magician" (fixes 404 at claude.com/plugins/magician)
- Use "./" self-reference source; move description to root level
- Bump version to 1.3.0

Bug fixes (user-reported):
- /manifest: add worktree gate (GATE 3.5) with branch proposal; Autonomous Continuation rule so pipeline doesn't stall after blueprint completes
- /portal: accept $ARGUMENTS so /manifest passes name without re-prompting
- /certify: auto-open browser for UI projects after starting dev server
- /seal: add CLAUDE.md + docs update step before commit; fix step numbering

Hook JSON fixes (validation errors):
- access-tracker.sh: "decision":"ask" → plain text
- pattern-detect.sh: "decision":"suggest" + "decision":"ask" → additionalContext
- format.sh: fix tool_input key extraction (was "input", breaking auto-format)

Design quality:
- /conjure GATE 3: design personality commitment gate before any CSS — forces a named direction (editorial, brutalist, luxury, retro-futuristic…); bans Inter, purple gradients, generic card layouts by name; brand book encodes personality + motion + spatial character, not just hex values

Other:
- /summon: add missing /magic to subagent skill registry
- agents: color frontmatter (reviewer=orange, sentinel=red, simplifier=cyan, verifier=green)
- README: simplify installation to single command