### PR TITLE
v4.9.0 — tunable output brevity (voice)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "magician",
       "description": "Full-stack SDLC plugin with dynamic project inspection, a local code knowledge-graph + cache, cross-session reference memory, self-learning, and parallel agent orchestration",
-      "version": "4.8.1",
+      "version": "4.9.0",
       "source": "./",
       "author": {
         "name": "Alexander Tyagunov",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magician",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "Full-stack SDLC plugin with dynamic project inspection, a local code knowledge-graph + cache, cross-session reference memory, self-learning, parallel agent orchestration, and feature comprehend→port/integrate (/transmute)",
   "author": {
     "name": "Alexander Tyagunov",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magician",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "Full-stack SDLC plugin with dynamic project inspection, a local code knowledge-graph + cache, cross-session reference memory, self-learning, and parallel agent orchestration.",
   "author": {
     "name": "Alexander Tyagunov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.0] — 2026-07-12
+
+**Tunable output brevity — lower token cost, no quality loss.** Output tokens cost several times more than input on every current model, so the cheapest saving on a coding-agent bill is simply emitting fewer of them. Magician now injects an output-brevity **voice** at session start — a style directive that trims filler while preserving every fact — with three levels and a leaner-than-default setting out of the box.
+
+### Added
+- **`voice` setting** — `magician-ui voice warrior|scribe|bard` (and `voice status`). Three levels, least → most wordy: **`warrior`** (minimal but complete — the shortest fully-correct answer, no preamble/examples/recaps), **`scribe`** (the default — leaner than usual; necessary explanation only), **`bard`** (standard/native verbosity, nothing injected). Resolution (first match wins): env `MAGICIAN_VOICE` → per-project `.magician/voice` → global `cli-ui.json` → default `scribe`.
+- **No-quality-loss directive** — for warrior/scribe, SessionStart injects a brevity directive that shortens by *cutting filler, not facts*: it drops preambles, postambles, restatements of the request, and recaps of work just done, and leads with the outcome — while keeping **all** substance and all code, commands, file paths, identifiers, numbers, and error text **verbatim**. It explicitly forbids compressing prose into fragments, telegraphese, arrow-chains, abbreviations, or jargon (readability over raw length), and never touches code, tests, diffs, or the actual work.
+- **`🗣 voice:` status-bar chip** — shows the active level live (warrior/scribe/bard), rendered locally at zero token cost; toggle its visibility with `magician-ui set …,voice`.
+
+### Notes
+- Auto-injection is a Claude Code SessionStart behavior (as with bundled lore); the `magician-ui voice` command and stored setting work everywhere. Takes effect at the next session start.
+- Default is `scribe` (leaner than standard), so sessions save output tokens from the first message. Set `bard` for the previous, fully-native verbosity.
+
 ## [4.8.1] — 2026-07-12
 
 **Hook performance — fewer Python cold-starts per turn, zero behavior change.** A profiling pass found the plugin's latency was dominated by Python process spawns (~26–52ms each): SessionStart spawned Python ~11 times, and every Bash tool call fired three separate hooks (two spawning Python). None of it was broken — just spawn-heavy. This release cuts the spawn count on the hot paths; every change is verified equivalent to the prior behavior.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br>
 
-[![Version](https://img.shields.io/badge/version-4.8.1-6C63FF?style=for-the-badge&labelColor=0b0b14)](https://github.com/Alexander-Tyagunov/magician/releases)
+[![Version](https://img.shields.io/badge/version-4.9.0-6C63FF?style=for-the-badge&labelColor=0b0b14)](https://github.com/Alexander-Tyagunov/magician/releases)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-a78bfa?style=for-the-badge&labelColor=0b0b14&logo=anthropic&logoColor=white)](https://code.claude.com)
 [![Codex](https://img.shields.io/badge/Codex-adapter-22d3ee?style=for-the-badge&labelColor=0b0b14)](https://github.com/Alexander-Tyagunov/magician)
 [![License](https://img.shields.io/badge/license-MIT-43e97b?style=for-the-badge&labelColor=0b0b14)](LICENSE)
@@ -12,7 +12,7 @@
 
 <h3>From idea to merged PR — autonomously, grounded in your code, gated only where it matters.</h3>
 
-<sub>25 skills · deep live-verified stack lore (languages · frameworks · databases · observability) · a local code knowledge-graph · cross-session memory · parallel agent orchestration · an absolute destructive-command guard · zero required deps</sub>
+<sub>25 skills · deep live-verified stack lore (languages · frameworks · databases · observability) · a local code knowledge-graph · cross-session memory · parallel agent orchestration · tunable output brevity (lower token cost) · an absolute destructive-command guard · zero required deps</sub>
 
 </div>
 
@@ -240,6 +240,24 @@ Always-injected **cores** stay small and bounded; the rich per-topic **deep-dive
 
 <img src="assets/divider.svg" alt="" width="100%">
 
+## 🗣 Voice — leaner output, lower cost &nbsp;<sub><code>new in 4.9.0</code></sub>
+
+> Output tokens are the expensive side of the bill (~5× input on current models). Say the same thing in fewer of them.
+
+magician sets an output-brevity **voice** every session — a style directive that trims filler while keeping every fact. A leaner voice cuts token cost with **no quality loss**, and it ships lean by default so you save from message one.
+
+| voice | wordiness | what it does |
+|---|---|---|
+| `warrior` | leanest | the shortest fully-correct answer — no preamble, unrequested examples, or closing recaps |
+| `scribe` &nbsp;*(default)* | leaner than usual | necessary explanation only; filler, restatements, and "what I just did" recaps trimmed |
+| `bard` | standard | native Claude/Codex verbosity — nothing injected |
+
+**It cuts filler, not facts.** All substance stays, and code, commands, file paths, and error text are kept **verbatim** — it never compresses prose into fragments, arrow-chains, or jargon (readability beats raw length).
+
+<sub>🗣 Set it with <code>magician-ui voice warrior|scribe|bard</code> — or per-project <code>.magician/voice</code> / env <code>MAGICIAN_VOICE</code> (first match wins, then the default <code>scribe</code>). The status bar shows <code>🗣 voice:scribe</code> live. Auto-injected into Claude Code sessions; the setting is stored for Codex too.</sub>
+
+<img src="assets/divider.svg" alt="" width="100%">
+
 ## 🔒 Safety — an absolute destructive-command guard &nbsp;<sub><code>new in 4.6.0</code></sub>
 
 > Security is infrastructure, not advice.
@@ -440,7 +458,7 @@ MCP-free Atlassian REST clients — throttle-aware, bulk-safe, one command per c
 <tr>
 <td width="50%" valign="top">
 <h4><code>magician-ui</code></h4>
-Manage the CLI UI status line + <code>allow</code> (read-only auto-approve) + <code>automode</code> (auto mode) — safe, backed-up <code>settings.json</code> edits.
+Manage the CLI UI status line + <code>allow</code> (read-only auto-approve) + <code>automode</code> (auto mode) + <code>voice</code> (output brevity) — safe, backed-up <code>settings.json</code> edits.
 </td>
 <td width="50%" valign="top">
 <h4><code>magician-scan</code> · <code>ctx</code></h4>

--- a/bin/magician-statusline
+++ b/bin/magician-statusline
@@ -16,7 +16,7 @@ import sys, os, json, subprocess, time, re
 HOME = os.environ.get("MAGICIAN_HOME") or os.path.expanduser("~/.claude/magician")
 CFG = os.path.join(HOME, "cli-ui.json")
 STATUS_DIR = os.path.join(HOME, "status")
-ALL_COMPONENTS = ["context", "rot", "spark", "meta", "skill", "effort", "lore"]
+ALL_COMPONENTS = ["context", "rot", "spark", "meta", "skill", "effort", "lore", "voice"]
 
 _ANSI = re.compile(r"\033\[[0-9;]*m")
 
@@ -237,6 +237,26 @@ def _lore(sid):
         return "", ""
 
 
+# warrior = leanest (most savings) → green; scribe = default → dim; bard = most output → yellow.
+_VOICE_COLOR = {"warrior": "green", "scribe": "dim", "bard": "yellow"}
+
+
+def _voice(sid):
+    """(label, color) for the voice chip from the per-session marker written by SessionStart.
+    Shows the output-brevity level shaping the session: `voice:warrior|scribe|bard`, or ('','')
+    when no marker exists."""
+    try:
+        p = os.path.join(STATUS_DIR, f"{sid}.voice.json")
+        if not os.path.exists(p):
+            return "", ""
+        lvl = (_load_json(p) or {}).get("level")
+        if not isinstance(lvl, str) or lvl not in _VOICE_COLOR:
+            return "", ""
+        return f"voice:{lvl}", _VOICE_COLOR[lvl]
+    except Exception:
+        return "", ""
+
+
 def _vlen(s):
     return len(_ANSI.sub("", s))
 
@@ -290,6 +310,13 @@ def main():
                 segs.append((5, _color("📚 " + ll, lc)))
         except Exception:
             pass   # a bad lore marker drops only this chip, never the whole bar
+    if "voice" in comps:
+        try:
+            vv, vc = _voice(sid)
+            if vv:
+                segs.append((6, _color("🗣 " + vv, vc)))
+        except Exception:
+            pass   # a bad voice marker drops only this chip, never the whole bar
     if "meta" in comps:
         m = []
         if model:

--- a/bin/magician-ui
+++ b/bin/magician-ui
@@ -25,8 +25,14 @@ HOME = os.environ.get("MAGICIAN_HOME") or os.path.expanduser("~/.claude/magician
 CFG = os.path.join(HOME, "cli-ui.json")
 SETTINGS = os.environ.get("MAGICIAN_SETTINGS") or os.path.expanduser("~/.claude/settings.json")
 INSTALLED = os.path.join(HOME, "statusline.py")   # stable path, version-independent
-ALL = ["context", "rot", "spark", "meta", "skill", "effort", "lore"]
+ALL = ["context", "rot", "spark", "meta", "skill", "effort", "lore", "voice"]
 MARK = "magician"   # substring used to recognise our own statusLine entry
+
+# Output-brevity levels (least → most wordy). warrior = leanest but complete,
+# scribe = the default (leaner than usual), bard = standard/native verbosity.
+# SessionStart injects a brevity directive for warrior/scribe (none for bard).
+VOICE_LEVELS = ["warrior", "scribe", "bard"]
+VOICE_DEFAULT = "scribe"
 
 # Read-only surface magician auto-approves so autonomous runs don't prompt per file/search.
 # ONLY safe read-only tools + commands — NEVER writes/commit/push/PR/delete (those stay gated).
@@ -279,6 +285,7 @@ def cmd_status(_args):
     print(f"settings:    statusLine {'wired to magician' if wired else 'not wired to magician'}")
     print(f"read-only allow: {cfg.get('allow', 'not set')} (auto-approve reads/searches/read-only git + jira·confluence reads + tests)")
     print(f"auto mode:   {cfg.get('automode', 'not set')} (Claude Code classifier: reads/aligned actions auto, writes/deploys/force-push gate — `magician-ui automode`)")
+    print(f"voice:       {cfg.get('voice', VOICE_DEFAULT)} (output brevity: warrior<scribe<bard; default scribe — `magician-ui voice <level>`)")
 
 
 def cmd_enable(args):
@@ -504,14 +511,47 @@ def cmd_lore(args):
               "(deep-dives stay on-demand, and repo rules always win). Disable: `magician-ui lore off`.")
 
 
+def cmd_voice(args):
+    """Set magician's output-brevity 'voice' — how wordy responses are, to lower output-token
+    cost with no quality loss (output tokens cost several times more than input). Three levels,
+    least → most wordy: `warrior` (minimal but complete), `scribe` (the default — leaner than
+    usual), `bard` (standard/native verbosity, nothing injected). SessionStart injects a brevity
+    directive for warrior/scribe that cuts filler (preambles, recaps, restating the request) while
+    keeping ALL substance and code/commands/errors verbatim — it never compresses prose into
+    fragments or jargon. `magician-ui voice <level>` sets it; `voice status` prints the state.
+    Resolution (first match wins): env MAGICIAN_VOICE → per-project `.magician/voice` → this
+    setting → default scribe. The status bar's `voice` chip shows it live. Takes effect next session."""
+    cfg = load_cfg()
+    if not args or args[0] in ("status", "--status"):
+        lvl = cfg.get("voice", VOICE_DEFAULT)
+        shown = "voice" in (cfg.get("components") or ALL)
+        print(f"voice level:     {lvl} (default: {VOICE_DEFAULT}; least→most wordy: {' < '.join(VOICE_LEVELS)})")
+        print(f"status-bar chip: {'shown' if shown else 'hidden'}  (toggle via `magician-ui set ...,voice`)")
+        print("overrides:       env `MAGICIAN_VOICE` · per-project `.magician/voice`")
+        return
+    lvl = args[0].strip().lower()
+    if lvl not in VOICE_LEVELS:
+        die(f"unknown voice '{args[0]}'; choose from: {', '.join(VOICE_LEVELS)}")
+    cfg["voice"] = lvl
+    cfg["updatedAt"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+    save_cfg(cfg)
+    blurb = {
+        "warrior": "minimal but complete — the shortest fully-correct answer; no preamble, examples, or recaps.",
+        "scribe":  "leaner than usual (default) — necessary explanation only, filler and restatements trimmed.",
+        "bard":    "standard/native verbosity — no brevity directive injected.",
+    }[lvl]
+    print(f"Voice set to {lvl}: {blurb}")
+    print("Substance, code, commands, paths, and errors are always kept verbatim. Takes effect next session start.")
+
+
 CMDS = {"status": cmd_status, "enable": cmd_enable, "set": cmd_set, "default": cmd_default,
         "disable": cmd_disable, "reconcile": cmd_reconcile, "allow": cmd_allow,
-        "automode": cmd_automode, "lore": cmd_lore}
+        "automode": cmd_automode, "lore": cmd_lore, "voice": cmd_voice}
 
 
 def main():
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
-        print("usage: magician-ui {status|enable [--all|--only a,b]|set <a,b>|default|disable|reconcile|allow [--off]|automode [--off|--available]|lore [on|off|status]}")
+        print("usage: magician-ui {status|enable [--all|--only a,b]|set <a,b>|default|disable|reconcile|allow [--off]|automode [--off|--available]|lore [on|off|status]|voice [warrior|scribe|bard|status]}")
         print(f"components: {', '.join(ALL)}")
         return
     cmd = sys.argv[1]

--- a/plugins/magician/.codex-plugin/plugin.json
+++ b/plugins/magician/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magician",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "Full-stack SDLC plugin with dynamic project inspection, a local code knowledge-graph + cache, cross-session reference memory, self-learning, and parallel agent orchestration.",
   "author": {
     "name": "Alexander Tyagunov",

--- a/plugins/magician/bin/magician-statusline
+++ b/plugins/magician/bin/magician-statusline
@@ -16,7 +16,7 @@ import sys, os, json, subprocess, time, re
 HOME = os.environ.get("MAGICIAN_HOME") or os.path.expanduser("~/.claude/magician")
 CFG = os.path.join(HOME, "cli-ui.json")
 STATUS_DIR = os.path.join(HOME, "status")
-ALL_COMPONENTS = ["context", "rot", "spark", "meta", "skill", "effort", "lore"]
+ALL_COMPONENTS = ["context", "rot", "spark", "meta", "skill", "effort", "lore", "voice"]
 
 _ANSI = re.compile(r"\033\[[0-9;]*m")
 
@@ -237,6 +237,26 @@ def _lore(sid):
         return "", ""
 
 
+# warrior = leanest (most savings) → green; scribe = default → dim; bard = most output → yellow.
+_VOICE_COLOR = {"warrior": "green", "scribe": "dim", "bard": "yellow"}
+
+
+def _voice(sid):
+    """(label, color) for the voice chip from the per-session marker written by SessionStart.
+    Shows the output-brevity level shaping the session: `voice:warrior|scribe|bard`, or ('','')
+    when no marker exists."""
+    try:
+        p = os.path.join(STATUS_DIR, f"{sid}.voice.json")
+        if not os.path.exists(p):
+            return "", ""
+        lvl = (_load_json(p) or {}).get("level")
+        if not isinstance(lvl, str) or lvl not in _VOICE_COLOR:
+            return "", ""
+        return f"voice:{lvl}", _VOICE_COLOR[lvl]
+    except Exception:
+        return "", ""
+
+
 def _vlen(s):
     return len(_ANSI.sub("", s))
 
@@ -290,6 +310,13 @@ def main():
                 segs.append((5, _color("📚 " + ll, lc)))
         except Exception:
             pass   # a bad lore marker drops only this chip, never the whole bar
+    if "voice" in comps:
+        try:
+            vv, vc = _voice(sid)
+            if vv:
+                segs.append((6, _color("🗣 " + vv, vc)))
+        except Exception:
+            pass   # a bad voice marker drops only this chip, never the whole bar
     if "meta" in comps:
         m = []
         if model:

--- a/plugins/magician/bin/magician-ui
+++ b/plugins/magician/bin/magician-ui
@@ -25,8 +25,14 @@ HOME = os.environ.get("MAGICIAN_HOME") or os.path.expanduser("~/.claude/magician
 CFG = os.path.join(HOME, "cli-ui.json")
 SETTINGS = os.environ.get("MAGICIAN_SETTINGS") or os.path.expanduser("~/.claude/settings.json")
 INSTALLED = os.path.join(HOME, "statusline.py")   # stable path, version-independent
-ALL = ["context", "rot", "spark", "meta", "skill", "effort", "lore"]
+ALL = ["context", "rot", "spark", "meta", "skill", "effort", "lore", "voice"]
 MARK = "magician"   # substring used to recognise our own statusLine entry
+
+# Output-brevity levels (least → most wordy). warrior = leanest but complete,
+# scribe = the default (leaner than usual), bard = standard/native verbosity.
+# SessionStart injects a brevity directive for warrior/scribe (none for bard).
+VOICE_LEVELS = ["warrior", "scribe", "bard"]
+VOICE_DEFAULT = "scribe"
 
 # Read-only surface magician auto-approves so autonomous runs don't prompt per file/search.
 # ONLY safe read-only tools + commands — NEVER writes/commit/push/PR/delete (those stay gated).
@@ -279,6 +285,7 @@ def cmd_status(_args):
     print(f"settings:    statusLine {'wired to magician' if wired else 'not wired to magician'}")
     print(f"read-only allow: {cfg.get('allow', 'not set')} (auto-approve reads/searches/read-only git + jira·confluence reads + tests)")
     print(f"auto mode:   {cfg.get('automode', 'not set')} (Claude Code classifier: reads/aligned actions auto, writes/deploys/force-push gate — `magician-ui automode`)")
+    print(f"voice:       {cfg.get('voice', VOICE_DEFAULT)} (output brevity: warrior<scribe<bard; default scribe — `magician-ui voice <level>`)")
 
 
 def cmd_enable(args):
@@ -504,14 +511,47 @@ def cmd_lore(args):
               "(deep-dives stay on-demand, and repo rules always win). Disable: `magician-ui lore off`.")
 
 
+def cmd_voice(args):
+    """Set magician's output-brevity 'voice' — how wordy responses are, to lower output-token
+    cost with no quality loss (output tokens cost several times more than input). Three levels,
+    least → most wordy: `warrior` (minimal but complete), `scribe` (the default — leaner than
+    usual), `bard` (standard/native verbosity, nothing injected). SessionStart injects a brevity
+    directive for warrior/scribe that cuts filler (preambles, recaps, restating the request) while
+    keeping ALL substance and code/commands/errors verbatim — it never compresses prose into
+    fragments or jargon. `magician-ui voice <level>` sets it; `voice status` prints the state.
+    Resolution (first match wins): env MAGICIAN_VOICE → per-project `.magician/voice` → this
+    setting → default scribe. The status bar's `voice` chip shows it live. Takes effect next session."""
+    cfg = load_cfg()
+    if not args or args[0] in ("status", "--status"):
+        lvl = cfg.get("voice", VOICE_DEFAULT)
+        shown = "voice" in (cfg.get("components") or ALL)
+        print(f"voice level:     {lvl} (default: {VOICE_DEFAULT}; least→most wordy: {' < '.join(VOICE_LEVELS)})")
+        print(f"status-bar chip: {'shown' if shown else 'hidden'}  (toggle via `magician-ui set ...,voice`)")
+        print("overrides:       env `MAGICIAN_VOICE` · per-project `.magician/voice`")
+        return
+    lvl = args[0].strip().lower()
+    if lvl not in VOICE_LEVELS:
+        die(f"unknown voice '{args[0]}'; choose from: {', '.join(VOICE_LEVELS)}")
+    cfg["voice"] = lvl
+    cfg["updatedAt"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+    save_cfg(cfg)
+    blurb = {
+        "warrior": "minimal but complete — the shortest fully-correct answer; no preamble, examples, or recaps.",
+        "scribe":  "leaner than usual (default) — necessary explanation only, filler and restatements trimmed.",
+        "bard":    "standard/native verbosity — no brevity directive injected.",
+    }[lvl]
+    print(f"Voice set to {lvl}: {blurb}")
+    print("Substance, code, commands, paths, and errors are always kept verbatim. Takes effect next session start.")
+
+
 CMDS = {"status": cmd_status, "enable": cmd_enable, "set": cmd_set, "default": cmd_default,
         "disable": cmd_disable, "reconcile": cmd_reconcile, "allow": cmd_allow,
-        "automode": cmd_automode, "lore": cmd_lore}
+        "automode": cmd_automode, "lore": cmd_lore, "voice": cmd_voice}
 
 
 def main():
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
-        print("usage: magician-ui {status|enable [--all|--only a,b]|set <a,b>|default|disable|reconcile|allow [--off]|automode [--off|--available]|lore [on|off|status]}")
+        print("usage: magician-ui {status|enable [--all|--only a,b]|set <a,b>|default|disable|reconcile|allow [--off]|automode [--off|--available]|lore [on|off|status]|voice [warrior|scribe|bard|status]}")
         print(f"components: {', '.join(ALL)}")
         return
     cmd = sys.argv[1]

--- a/plugins/magician/source-skills/statusline/SKILL.md
+++ b/plugins/magician/source-skills/statusline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: statusline
-description: Enable, configure, or disable the Magician CLI status line ("Magician Claude CLI UI") — a lightweight, always-on bar showing live context %, a context-rot warning, a token-flow sparkline, model · git · cost, the active skill/workflow/loop, and the current reasoning effort/mode. Use when the user says "enable/turn on the magician UI / status line / status bar", "show my context/tokens/effort in the console", "configure/change what the bar shows", "what should the status line display", or "turn off / disable the status line".
+description: Enable, configure, or disable the Magician CLI status line ("Magician Claude CLI UI") — a lightweight, always-on bar showing live context %, a context-rot warning, a token-flow sparkline, model · git · cost, the active skill/workflow/loop, the reasoning effort/mode, the bundled-lore state, and the output-brevity "voice" level. Also sets the output-brevity voice (warrior/scribe/bard). Use when the user says "enable/turn on the magician UI / status line / status bar", "show my context/tokens/effort in the console", "configure/change what the bar shows", "what should the status line display", "turn off / disable the status line", or "make output shorter/leaner / set the voice / reduce token cost".
 allowed-tools: Bash(magician-ui:*), AskUserQuestion, Read
 argument-hint: [enable · disable · status · set <components>]
 ---
@@ -19,6 +19,8 @@ A native Claude Code **status line** rendered by magician. It runs **locally, co
 | `meta` | model · git branch · session cost |
 | `skill` | the active magician skill / workflow / running-agent count / loop round |
 | `effort` | 🧠 the live reasoning **effort** (low/medium/high/xhigh/max) — the default shows on open and tracks `/effort` changes automatically (from Claude Code's `effort.level`) — or the magician **mode** you set, e.g. `ultracode` (which otherwise reports as `xhigh`); say "set mode to ultracode" / "exit ultracode" to change it |
+| `lore` | 📚 whether magician's bundled stack lore is shaping the session — `lore:N` (N cores injected) or `lore:off` |
+| `voice` | 🗣 the output-brevity **voice** — `voice:warrior` (leanest) · `voice:scribe` (default) · `voice:bard` (standard); set with `magician-ui voice <level>` |
 
 ## Actions
 
@@ -35,6 +37,7 @@ A native Claude Code **status line** rendered by magician. It runs **locally, co
 - **Disable** — `magician-ui disable` (removes only magician's `statusLine`; records the opt-out so it isn't suggested again; re-enable anytime on request).
 - **Auto mode (real autonomy)** — `magician-ui automode` turns on Claude Code's **auto** permission mode (`defaultMode: auto` + `CLAUDE_CODE_ENABLE_AUTO_MODE=1`, required on Vertex/Bedrock/Foundry). Its classifier auto-approves reads + request-aligned work and **gates** writes/deploys/force-push/destructive ops — the true "reads proceed, writes gate." A plugin can't switch the mode of a live session, so **restart** to enter it; `automode --off` reverts. Falls back to Manual if the account/model doesn't support auto.
 - **Read-only auto-approve (acceptEdits fallback)** — `magician-ui allow` merges a read-only allow-list (Read/Grep/Glob/LS + read-only git + kg/ctx + **jira/confluence reads** + test/lint/build runners + gh reads) into `settings.json` so non-auto sessions don't prompt per read; jira/confluence **writes**, commit/push/PR/delete still gate. Applied on install/upgrade; `magician-ui allow --off`. (Jira/Confluence use magician's MCP-free CLIs — magician nudges sessions off any ambient Atlassian MCP.) See [lore/autonomy.md](../../lore/autonomy.md).
+- **Voice — output brevity (lower token cost, no quality loss)** — `magician-ui voice warrior|scribe|bard` sets how wordy responses are. Output tokens cost several× input, so leaner output is the cheapest saving. Levels least→most wordy: **`warrior`** (minimal but complete), **`scribe`** (the default — leaner than usual), **`bard`** (standard/native). SessionStart injects a brevity directive for warrior/scribe that cuts filler (preambles, recaps, restating the request) while keeping **all** substance and code/commands/errors verbatim — it never compresses prose into fragments or jargon. `magician-ui voice status` shows the current level. Overrides (first match wins): env `MAGICIAN_VOICE` → per-project `.magician/voice` → this setting → default `scribe`. Takes effect next session start; the `🗣 voice:` chip shows it live.
 
 ## Rules
 

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -382,6 +382,39 @@ else
   LORE_NOTE="No stack markers found. Run /almanac to initialize workspace."
 fi
 
+# ── Voice — output-brevity level (default scribe) ─────────────────────────────
+# Fewer OUTPUT tokens = lower cost (output costs several× input) with NO quality loss: the
+# injected directive cuts filler (preambles, recaps, restating the request) but keeps ALL
+# substance and code/commands/errors verbatim — it never compresses prose into fragments/jargon.
+# Levels least→most wordy: warrior (minimal) · scribe (default, leaner) · bard (native, no inject).
+# Resolution (first match wins): env MAGICIAN_VOICE → per-project .magician/voice → cli-ui.json → scribe.
+VOICE_LEVEL="scribe"
+_vc=""
+case "$(printf '%s' "${MAGICIAN_VOICE:-}" | tr '[:upper:]' '[:lower:]')" in
+  warrior|scribe|bard) _vc="$(printf '%s' "$MAGICIAN_VOICE" | tr '[:upper:]' '[:lower:]')" ;;
+esac
+if [ -z "$_vc" ] && [ -f ".magician/voice" ]; then
+  _pv="$(tr '[:upper:]' '[:lower:]' < .magician/voice | tr -d '[:space:]' || true)"
+  case "$_pv" in warrior|scribe|bard) _vc="$_pv" ;; esac
+fi
+if [ -z "$_vc" ] && [ -f "$LORE_UICFG" ]; then   # portable extract (grep -oE works on BSD + GNU)
+  _cv="$(grep -oE '"voice"[[:space:]]*:[[:space:]]*"(warrior|scribe|bard)"' "$LORE_UICFG" 2>/dev/null | grep -oE 'warrior|scribe|bard' | head -1 || true)"
+  case "$_cv" in warrior|scribe|bard) _vc="$_cv" ;; esac
+fi
+[ -n "$_vc" ] && VOICE_LEVEL="$_vc"
+
+VOICE_CORE="[MAGICIAN VOICE — output brevity] Output tokens cost several times more than input, so keep responses lean; brevity is the cheapest quality-preserving win. Preserve ALL substance — every claim, step, and caveat — and keep code, commands, file paths, identifiers, numbers, and error text VERBATIM. Shorten by cutting filler, not facts: drop preambles ('Let me…', 'I'll now…', 'Great question'), postambles, restatements of the request, and recaps of what you just did; lead with the outcome. Do NOT compress into fragments, telegraphese, arrow-chains (A→B→fails), abbreviations, or invented jargon — readability matters more than raw length. This shapes prose only; never trim or abbreviate code, tests, diffs, or the actual work."
+case "$VOICE_LEVEL" in
+  warrior) VOICE_NOTE="
+
+${VOICE_CORE} Level warrior (minimal): give the shortest response that is fully correct and complete — omit optional commentary, unrequested examples, and closing summaries; use tight prose or short bullets. When the answer is a single fact or action, state just that." ;;
+  scribe)  VOICE_NOTE="
+
+${VOICE_CORE} Level scribe (default): keep necessary explanation and structure, trimmed to what changes the reader's next action." ;;
+  *)       VOICE_NOTE="" ;;   # bard → native verbosity, nothing injected
+esac
+VOICE_MARKER="$MAG_STATUS/${SID_SAFE}.voice.json"
+
 # ── Chronicle injection ──────────────────────────────────────────────────────
 CHRONICLE_NOTE=""
 LATEST=$(ls -t "$PLUGIN_DATA/chronicle/"*.json 2>/dev/null | head -1 || true)
@@ -552,14 +585,19 @@ CONTEXT="[MAGICIAN SESSION] At the very start of your first response, greet the 
 ${CAT_ART}
 ✦ magician${TECHS:+ · ${TECHS}}${ARCHETYPE:+ · ${ARCHETYPE}}
 
-${LORE_NOTE}${CHRONICLE_NOTE}${RESUME_NOTE}${REFERENCES_NOTE}${LEARN_NOTE}${STRATEGY_NOTE}${FIRST_RUN_NOTE}${KG_NOTE:+ ${KG_NOTE}}${OBS_NOTE}${UI_NOTE:+ ${UI_NOTE}}${REMEMBER_HINT}${DOCTRINE_NOTE}"
-python3 - "$CONTEXT" "$LORE_MARKER" "$LORE_ENABLED" "$LORE_INJECTED" <<'PYEOF'
+${LORE_NOTE}${CHRONICLE_NOTE}${RESUME_NOTE}${REFERENCES_NOTE}${LEARN_NOTE}${STRATEGY_NOTE}${FIRST_RUN_NOTE}${KG_NOTE:+ ${KG_NOTE}}${OBS_NOTE}${UI_NOTE:+ ${UI_NOTE}}${REMEMBER_HINT}${DOCTRINE_NOTE}${VOICE_NOTE}"
+python3 - "$CONTEXT" "$LORE_MARKER" "$LORE_ENABLED" "$LORE_INJECTED" "$VOICE_MARKER" "$VOICE_LEVEL" <<'PYEOF'
 import json, sys, time
 ctx, marker, enabled, injected = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+voice_marker, voice_level = sys.argv[5], sys.argv[6]
 try:                                           # write the lore status marker (for the CLI UI chip)
     cores = (injected or "").split()
     json.dump({"enabled": enabled == "1", "count": len(cores), "cores": cores, "ts": time.time()},
               open(marker, "w"))
+except Exception:
+    pass
+try:                                           # write the voice status marker (for the CLI UI chip)
+    json.dump({"level": voice_level, "ts": time.time()}, open(voice_marker, "w"))
 except Exception:
     pass
 print(json.dumps({"additionalContext": ctx}))  # the SessionStart additionalContext (unchanged)

--- a/skills/statusline/SKILL.md
+++ b/skills/statusline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: statusline
-description: Enable, configure, or disable the Magician CLI status line ("Magician Claude CLI UI") — a lightweight, always-on bar showing live context %, a context-rot warning, a token-flow sparkline, model · git · cost, the active skill/workflow/loop, and the current reasoning effort/mode. Use when the user says "enable/turn on the magician UI / status line / status bar", "show my context/tokens/effort in the console", "configure/change what the bar shows", "what should the status line display", or "turn off / disable the status line".
+description: Enable, configure, or disable the Magician CLI status line ("Magician Claude CLI UI") — a lightweight, always-on bar showing live context %, a context-rot warning, a token-flow sparkline, model · git · cost, the active skill/workflow/loop, the reasoning effort/mode, the bundled-lore state, and the output-brevity "voice" level. Also sets the output-brevity voice (warrior/scribe/bard). Use when the user says "enable/turn on the magician UI / status line / status bar", "show my context/tokens/effort in the console", "configure/change what the bar shows", "what should the status line display", "turn off / disable the status line", or "make output shorter/leaner / set the voice / reduce token cost".
 allowed-tools: Bash(magician-ui:*), AskUserQuestion, Read
 argument-hint: [enable · disable · status · set <components>]
 ---
@@ -19,6 +19,8 @@ A native Claude Code **status line** rendered by magician. It runs **locally, co
 | `meta` | model · git branch · session cost |
 | `skill` | the active magician skill / workflow / running-agent count / loop round |
 | `effort` | 🧠 the live reasoning **effort** (low/medium/high/xhigh/max) — the default shows on open and tracks `/effort` changes automatically (from Claude Code's `effort.level`) — or the magician **mode** you set, e.g. `ultracode` (which otherwise reports as `xhigh`); say "set mode to ultracode" / "exit ultracode" to change it |
+| `lore` | 📚 whether magician's bundled stack lore is shaping the session — `lore:N` (N cores injected) or `lore:off` |
+| `voice` | 🗣 the output-brevity **voice** — `voice:warrior` (leanest) · `voice:scribe` (default) · `voice:bard` (standard); set with `magician-ui voice <level>` |
 
 ## Actions
 
@@ -35,6 +37,7 @@ A native Claude Code **status line** rendered by magician. It runs **locally, co
 - **Disable** — `magician-ui disable` (removes only magician's `statusLine`; records the opt-out so it isn't suggested again; re-enable anytime on request).
 - **Auto mode (real autonomy)** — `magician-ui automode` turns on Claude Code's **auto** permission mode (`defaultMode: auto` + `CLAUDE_CODE_ENABLE_AUTO_MODE=1`, required on Vertex/Bedrock/Foundry). Its classifier auto-approves reads + request-aligned work and **gates** writes/deploys/force-push/destructive ops — the true "reads proceed, writes gate." A plugin can't switch the mode of a live session, so **restart** to enter it; `automode --off` reverts. Falls back to Manual if the account/model doesn't support auto.
 - **Read-only auto-approve (acceptEdits fallback)** — `magician-ui allow` merges a read-only allow-list (Read/Grep/Glob/LS + read-only git + kg/ctx + **jira/confluence reads** + test/lint/build runners + gh reads) into `settings.json` so non-auto sessions don't prompt per read; jira/confluence **writes**, commit/push/PR/delete still gate. Applied on install/upgrade; `magician-ui allow --off`. (Jira/Confluence use magician's MCP-free CLIs — magician nudges sessions off any ambient Atlassian MCP.) See [lore/autonomy.md](../../lore/autonomy.md).
+- **Voice — output brevity (lower token cost, no quality loss)** — `magician-ui voice warrior|scribe|bard` sets how wordy responses are. Output tokens cost several× input, so leaner output is the cheapest saving. Levels least→most wordy: **`warrior`** (minimal but complete), **`scribe`** (the default — leaner than usual), **`bard`** (standard/native). SessionStart injects a brevity directive for warrior/scribe that cuts filler (preambles, recaps, restating the request) while keeping **all** substance and code/commands/errors verbatim — it never compresses prose into fragments or jargon. `magician-ui voice status` shows the current level. Overrides (first match wins): env `MAGICIAN_VOICE` → per-project `.magician/voice` → this setting → default `scribe`. Takes effect next session start; the `🗣 voice:` chip shows it live.
 
 ## Rules
 


### PR DESCRIPTION
## v4.9.0 — Voice: tunable output brevity, lower token cost, no quality loss

Output tokens cost ~5× input on current models, so emitting fewer of them is the cheapest saving on a coding-agent bill. This ships a **`voice`** setting — a SessionStart-injected brevity directive (same path as bundled lore) with three levels, defaulting to a leaner-than-standard level so sessions save from message one.

### Levels (least → most wordy)
- **`warrior`** — minimal but complete: the shortest fully-correct answer; no preamble, unrequested examples, or closing recaps
- **`scribe`** *(default)* — leaner than usual: necessary explanation only; filler, restatements, and recaps trimmed
- **`bard`** — standard/native verbosity: nothing injected

### No quality loss
The directive shortens by **cutting filler, not facts** — it keeps all substance and all code, commands, file paths, identifiers, and error text **verbatim**, and explicitly forbids compressing prose into fragments, arrow-chains, or jargon (readability over raw length). Shapes prose only; never touches code, tests, diffs, or the work.

### Manage it
- `magician-ui voice warrior|scribe|bard` (+ `voice status`)
- Overrides (first match wins): env `MAGICIAN_VOICE` → per-project `.magician/voice` → `cli-ui.json` → default `scribe`
- Live `🗣 voice:` status-bar chip (rendered locally, zero tokens)
- Auto-injection is a Claude Code SessionStart behavior; the CLI + stored setting also work for Codex

### Also
- Docs: README "Voice" section, `/statusline` skill, CHANGELOG
- Version 4.8.1 → 4.9.0; Codex package regenerated (`build_package.py --check` clean)
- Verified: 21/21 repo tests pass; CLI, chip render/hide, per-level injection + precedence, and a no-external-refs leak scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)